### PR TITLE
Fix duel websocket registration bug

### DIFF
--- a/backend/internal/ws/handler.go
+++ b/backend/internal/ws/handler.go
@@ -79,6 +79,9 @@ func ServeDuelWS(c echo.Context, hub *Hub, userID string) error {
 		duelService: hub.duelService,
 	}
 
+	// クライアント登録
+	client.hub.register <- client
+
 	// 対戦データを取得して送信
 	duel, err := hub.duelService.GetDuel(duelID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure clients connecting to `/ws/duel` are registered with the hub

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842c53f48cc8324a8275305c57eb884