### PR TITLE
Fix duel creation via matchmaking API

### DIFF
--- a/backend/internal/game/service.go
+++ b/backend/internal/game/service.go
@@ -207,11 +207,24 @@ func (ds *DuelService) checkGameEnd(duel *Duel) {
 }
 
 // CreateDuel は新しい対戦を作成します
+// CreateDuel creates a new duel and returns its generated ID.
 func (ds *DuelService) CreateDuel(player1ID, player2ID string) (string, error) {
+	duelID := uuid.New().String()
+	if err := ds.CreateDuelWithID(duelID, player1ID, player2ID); err != nil {
+		return "", err
+	}
+	return duelID, nil
+}
+
+// CreateDuelWithID creates a new duel using the provided ID.
+func (ds *DuelService) CreateDuelWithID(duelID, player1ID, player2ID string) error {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 
-	duelID := uuid.New().String()
+	if _, exists := ds.duels[duelID]; exists {
+		return fmt.Errorf("duel %s already exists", duelID)
+	}
+
 	duel := &Duel{
 		ID:        duelID,
 		Players:   [2]Player{{UserID: player1ID}, {UserID: player2ID}},
@@ -219,7 +232,7 @@ func (ds *DuelService) CreateDuel(player1ID, player2ID string) (string, error) {
 		TurnCount: 1,
 	}
 	ds.duels[duelID] = duel
-	return duelID, nil
+	return nil
 }
 
 // GetDuel は対戦情報を取得します

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -108,7 +108,7 @@ func setupRoutes(e *echo.Echo, cfg *Config) {
 
 	// マッチング用リポジトリとAPI
 	matchmakingRepo := db.NewMatchmakingRepository(dbConn)
-	matchmakingAPI := game.NewMatchmakingAPI(matchmakingRepo)
+	matchmakingAPI := game.NewMatchmakingAPI(matchmakingRepo, hub.GetDuelService())
 
 	// マッチングAPIエンドポイント
 	api.POST("/matchmaking/join", matchmakingAPI.Join)

--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -188,3 +188,8 @@ func (h *Hub) startCleanupTask() {
 		}
 	}
 }
+
+// GetDuelService returns the duel service managed by the hub.
+func (h *Hub) GetDuelService() *game.DuelService {
+	return h.duelService
+}


### PR DESCRIPTION
## Summary
- create duel in DuelService when matchmaking API pairs players
- allow creating duel with a predefined ID
- expose hub's duel service to router and use it in MatchmakingAPI

## Testing
- `go test ./...` *(passes: no packages)*
- `go build ./...` *(fails: none)*
- `npm test --silent` *(fails: config must export or return an object)*

------
https://chatgpt.com/codex/tasks/task_e_6842cb2a9e5c83249978ee746e4d7784